### PR TITLE
laravel5.8へのアップデート対応

### DIFF
--- a/src/Handler/AirbrakeExceptionHandler.php
+++ b/src/Handler/AirbrakeExceptionHandler.php
@@ -65,4 +65,16 @@ class AirbrakeExceptionHandler implements ExceptionHandler
     {
         return $this->handler->renderForConsole($output, $e);
     }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Exception  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function shouldReport(Exception $e)
+    {
+        return true;
+    }
 }

--- a/src/Handler/AirbrakeExceptionHandler.php
+++ b/src/Handler/AirbrakeExceptionHandler.php
@@ -67,11 +67,10 @@ class AirbrakeExceptionHandler implements ExceptionHandler
     }
 
     /**
-     * Render an exception into an HTTP response.
+     * Determine if the exception should be reported.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return bool
      */
     public function shouldReport(Exception $e)
     {


### PR DESCRIPTION
laravel5.8でExceptionHandler interfaceにshouldReport methodが追加されたので継承先クラスに実装しました。
ご確認お願いいたします。

laravel5.1, 5.8での動作確認済みです。